### PR TITLE
Fix backend url

### DIFF
--- a/interface/src/lib/helpers/constants.ts
+++ b/interface/src/lib/helpers/constants.ts
@@ -10,8 +10,8 @@ export const OAUTH_SCOPE = env.PUBLIC_OAUTH_SCOPE || 'PROFILE:READ ASSETS:READ S
 export const MIXIN_MESSENGER_INSTALL = env.PUBLIC_MIXIN_MESSENGER_INSTALL || 'https://messenger.mixin.one/install'
 export const MIXIN_API_BASE_URL = env.PUBLIC_MIXIN_API_BASE_URL || 'https://api.mixin.one'
 
-export const HUFI_SOCKET_URL = env.PUBLIC_HUFI_SOCKET_URL || '//bc6e1fa0-3c5a-4235-809c-c4fcc4a5d859.mvg.fi'
-export const HUFI_BACKEND_URL = env.PUBLIC_HUFI_BACKEND_URL || 'https://bc6e1fa0-3c5a-4235-809c-c4fcc4a5d859.mvg.fi:3000'
+export const HUFI_SOCKET_URL = env.PUBLIC_HUFI_SOCKET_URL || '//mrmarket-pr.up.railway.app/'
+export const HUFI_BACKEND_URL = env.PUBLIC_HUFI_BACKEND_URL || 'https://mrmarket-pr.up.railway.app/'
 export const HUMAN_PROTOCOL_GROUP_URL = env.PUBLIC_HUMAN_PROTOCOL_GROUP_URL || 'https://mixin.one/apps/5a33fc52-f445-4170-a06a-47f8be94a8f3'
 
 export const SUPPORTED_PAIRS: {

--- a/interface/src/lib/helpers/constants.ts
+++ b/interface/src/lib/helpers/constants.ts
@@ -10,8 +10,8 @@ export const OAUTH_SCOPE = env.PUBLIC_OAUTH_SCOPE || 'PROFILE:READ ASSETS:READ S
 export const MIXIN_MESSENGER_INSTALL = env.PUBLIC_MIXIN_MESSENGER_INSTALL || 'https://messenger.mixin.one/install'
 export const MIXIN_API_BASE_URL = env.PUBLIC_MIXIN_API_BASE_URL || 'https://api.mixin.one'
 
-export const HUFI_SOCKET_URL = env.PUBLIC_HUFI_SOCKET_URL || '//mrmarket-pr.up.railway.app/'
-export const HUFI_BACKEND_URL = env.PUBLIC_HUFI_BACKEND_URL || 'https://mrmarket-pr.up.railway.app/'
+export const HUFI_SOCKET_URL = env.PUBLIC_HUFI_SOCKET_URL || '//mrmarket-pr.up.railway.app'
+export const HUFI_BACKEND_URL = env.PUBLIC_HUFI_BACKEND_URL || 'https://mrmarket-pr.up.railway.app'
 export const HUMAN_PROTOCOL_GROUP_URL = env.PUBLIC_HUMAN_PROTOCOL_GROUP_URL || 'https://mixin.one/apps/5a33fc52-f445-4170-a06a-47f8be94a8f3'
 
 export const SUPPORTED_PAIRS: {


### PR DESCRIPTION
## **User description**
The backend url '/' caused api request failure.

But after the modification, the websocket is still not working. Maybe the backend needs to be fixed.


___

## **Type**
bug_fix


___

## **Description**
- Updated `HUFI_SOCKET_URL` and `HUFI_BACKEND_URL` in `constants.ts` to remove trailing slashes, fixing potential issues with API requests and WebSocket connections.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constants.ts</strong><dd><code>Update Backend and Socket URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

interface/src/lib/helpers/constants.ts
<li>Updated <code>HUFI_SOCKET_URL</code> and <code>HUFI_BACKEND_URL</code> to remove trailing <br>slashes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/60/files#diff-1d9500711f0f58654b9e0e95aa0e7fdc798a0b74f1c2310b09e52123e52d6bf2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

