### PR TITLE
disable dark mode

### DIFF
--- a/interface/src/lib/components/home/user/settings.svelte
+++ b/interface/src/lib/components/home/user/settings.svelte
@@ -8,7 +8,7 @@
 
   const items = [
     {key: 'lang', name: $_('language'), value: getNameByKey($locale || 'en-US'), fn: ()=>{goto('/home/user/i18n')}},
-    {key: 'theme', name: $_('theme'), value: 0, fn: ()=>{}},
+    // {key: 'theme', name: $_('theme'), value: 0, fn: ()=>{}},
     {key: 'quotation', name: $_('quotation'), value: 0, fn: ()=>{}},
     {key: 'faq', name: $_('faq'), value: 0, fn: ()=>{}},
     {key: 'us', name: $_('about_us'), value: 0, fn: ()=>{}},

--- a/interface/src/routes/+layout.svelte
+++ b/interface/src/routes/+layout.svelte
@@ -5,11 +5,11 @@
 	import { initi18n as i18n } from "../i18n/i18n";
 	import { autoConnectMixin, checkMixinTokenExist } from "$lib/stores/wallet";
 	import Loading from "$lib/components/home/loading.svelte";
-	import { detectSystemDark, theme } from "$lib/stores/theme";
+	import { theme } from "$lib/stores/theme";
 
 	const init = async () => {
 		await i18n();
-		detectSystemDark();
+		// detectSystemDark();
 		if (checkMixinTokenExist()) {
 			await autoConnectMixin();
 		}


### PR DESCRIPTION
## **User description**
Disable dark mode for design reasons


___

## **Type**
enhancement


___

## **Description**
- Disabled the theme selection option in the user settings to adhere to design consistency.
- Removed automatic dark mode detection to ensure the application does not switch themes based on system settings.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.svelte</strong><dd><code>Disable Theme Selection in User Settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

interface/src/lib/components/home/user/settings.svelte
- Commented out the theme selection option in the user settings.



</details>
    

  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/133/files#diff-b2e3034ae6c78f2040b654657cf8d847484fa38da5d19b609f5f2b4aaf392958">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>+layout.svelte</strong><dd><code>Remove Automatic Dark Mode Detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

interface/src/routes/+layout.svelte
<li>Removed the call to <code>detectSystemDark</code> to disable automatic dark mode <br>detection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/133/files#diff-e96a968b8583d27dc8644f70ee570534563be0eefbe4454ec1b542afa35df24f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

