### PR TITLE
update deployment in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ npm run test:e2e
 
 ## Deployment
 
-1. Click <a href="https://railway.app/template/bveg2P?referralCode=j8dZGz"><img src="https://railway.app/button.svg" alt="Deploy on Railway" width="64px"></a> button to deploy server on railway. It's possible that the `Trial Plan` doesn't have enough memory to run the server. We suggest to upgrade.
+1. Click <a href="https://railway.app/template/bveg2P?referralCode=j8dZGz"><img src="https://railway.app/button.svg" alt="Deploy on Railway" width="64px"></a> button to deploy server on railway. It's possible that the `Trial Plan` of railway doesn't have enough memory to run the server. We suggest to upgrade.
 
 2. Click <a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FHu-Fi%2FMr.Market&env=PUBLIC_BOT_ID,PUBLIC_HUFI_BACKEND_URL,PUBLIC_HUFI_SOCKET_URL&root-directory=interface"><img src="https://vercel.com/button" alt="Deploy with Vercel" width="52px"></a> button to deploy interface on vercel, fill the environment variables from railway deployment and mixin keystore. If you don't have a mixin keystore already, go to [Mixin developer dashboard](https://developers.mixin.one/dashboard) to get one.
 

--- a/README.md
+++ b/README.md
@@ -77,13 +77,9 @@ npm run test:e2e
 
 ## Deployment
 
-1. Click <a href="https://railway.app/template/bveg2P?referralCode=j8dZGz"><img src="https://railway.app/button.svg" alt="Deploy on Railway" width="64px"></a> button to deploy server on railway
+1. Click <a href="https://railway.app/template/bveg2P?referralCode=j8dZGz"><img src="https://railway.app/button.svg" alt="Deploy on Railway" width="64px"></a> button to deploy server on railway. It's possible that the `Trial Plan` doesn't have enough memory to run the server. We suggest to upgrade.
 
-2. Click <a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FHu-Fi%2FMr.Market&env=PUBLIC_BOT_ID,PUBLIC_HUFI_BACKEND_URL,PUBLIC_HUFI_SOCKET_URL&root-directory=interface"><img src="https://vercel.com/button" alt="Deploy with Vercel" width="52px"></a> button to deploy interface on vercel
-
-3. Open project settings, set the 'Root directory' to `interface`, update environment variables get from server deployment
-
-4. Restart deployment
+2. Click <a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FHu-Fi%2FMr.Market&env=PUBLIC_BOT_ID,PUBLIC_HUFI_BACKEND_URL,PUBLIC_HUFI_SOCKET_URL&root-directory=interface"><img src="https://vercel.com/button" alt="Deploy with Vercel" width="52px"></a> button to deploy interface on vercel, fill the environment variables from railway deployment and mixin keystore. If you don't have a mixin keystore already, go to [Mixin developer dashboard](https://developers.mixin.one/dashboard) to get one.
 
 ## Built With
 


### PR DESCRIPTION
## **Type**
Enhancement, Documentation


___

## **Description**
- Enhanced the deployment section in the README to provide more detailed instructions and warnings about potential issues:
  - Added a note about the possible insufficiency of Railway's `Trial Plan` for running the server, suggesting an upgrade.
  - Updated the Vercel deployment steps to guide users through filling in environment variables and obtaining a Mixin keystore if they don't already have one.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update Deployment Instructions in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md
<li>Updated deployment instructions for Railway to include a note on the <br>potential need for a plan upgrade.<br> <li> Revised Vercel deployment instructions to include steps for setting <br>environment variables and obtaining a Mixin keystore.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/155/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

