### PR TITLE
fix ios input decimal bug

### DIFF
--- a/interface/src/lib/components/grow/arbitrage/new/easy/exchanges.svelte
+++ b/interface/src/lib/components/grow/arbitrage/new/easy/exchanges.svelte
@@ -230,6 +230,7 @@
           <div class="join border rounded-lg items-center w-44">
             <input
               type="tel"
+              inputmode="decimal"
               use:cleave={maskOption}
               class={clsx(
                 "input focus:border-none focus:outline-none join-item w-full",

--- a/interface/src/lib/components/grow/marketMaking/new/easy/amount.svelte
+++ b/interface/src/lib/components/grow/marketMaking/new/easy/amount.svelte
@@ -32,7 +32,7 @@
     </div>
 
     <div class="join border rounded-lg items-center">
-      <input type="tel" use:cleave={maskOption} data-testid="amount-input-0" bind:value={$createMMEasyAmounts[0]} class={clsx("input focus:border-none focus:outline-none w-32 join-item")} />
+      <input inputmode="decimal" type="tel" use:cleave={maskOption} data-testid="amount-input-0" bind:value={$createMMEasyAmounts[0]} class={clsx("input focus:border-none focus:outline-none w-32 join-item")} />
       <div class="join-item mr-2 w-12 text-end">
         <span class="text-sm opacity-40"> {baseAssetSymbol} </span>
       </div>
@@ -48,7 +48,7 @@
     </div>
 
     <div class="join border rounded-lg items-center">
-      <input type="tel" use:cleave={maskOption} data-testid="amount-input-1" bind:value={$createMMEasyAmounts[1]} class={clsx("input focus:border-none focus:outline-none w-32 join-item")} />
+      <input inputmode="decimal" type="tel" use:cleave={maskOption} data-testid="amount-input-1" bind:value={$createMMEasyAmounts[1]} class={clsx("input focus:border-none focus:outline-none w-32 join-item")} />
       <div class="join-item mr-2 w-12 text-end">
         <span class="text-sm opacity-40"> {targetAssetSymbol} </span>
       </div>

--- a/interface/src/lib/components/spot/bids/inputs.svelte
+++ b/interface/src/lib/components/spot/bids/inputs.svelte
@@ -197,6 +197,7 @@
     {#if $orderTypeLimit}
       <input
         type="tel"
+        inputmode="decimal"
         use:cleave={maskOption}
         bind:value={$limitPrice}
         placeholder={$_("price")}
@@ -231,6 +232,7 @@
     >
       <input
         type="tel"
+        inputmode="decimal"
         on:keyup={getTotal}
         use:cleave={maskOption}
         bind:value={$limitAmount}
@@ -275,6 +277,7 @@
     {#if $orderTypeLimit}
       <input
         type="tel"
+        inputmode="decimal"
         on:keyup={getAmount}
         use:cleave={maskOption}
         bind:value={$limitTotal}
@@ -284,6 +287,7 @@
     {:else if $orderTypeMarket}
       <input
         type="tel"
+        inputmode="decimal"
         on:keyup={getTotal}
         use:cleave={maskOption}
         bind:value={$marketAmount}

--- a/interface/src/lib/components/swap/input.svelte
+++ b/interface/src/lib/components/swap/input.svelte
@@ -81,6 +81,7 @@
     
     <input
       type="tel"
+      inputmode="decimal"
       data-testid="input-amount"
       use:cleave={maskOption}
       bind:value={$Input}

--- a/interface/src/lib/components/swap/output.svelte
+++ b/interface/src/lib/components/swap/output.svelte
@@ -81,6 +81,7 @@
     
     <input
       type="tel"
+      inputmode="decimal"
       data-testid="output-amount"
       use:cleave={maskOption}
       bind:value={$Output}


### PR DESCRIPTION
## **Type**
bug_fix, enhancement


___

## **Description**
- Added `inputmode="decimal"` attribute to various input fields across multiple components to fix and enhance numeric input handling on iOS devices.
- This change affects components used in arbitrage, market making, spot bids, and swap functionalities.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exchanges.svelte</strong><dd><code>Enhance Numeric Input for iOS in Arbitrage Exchanges Component</code></dd></summary>
<hr>

interface/src/lib/components/grow/arbitrage/new/easy/exchanges.svelte
<li>Added <code>inputmode="decimal"</code> to the input field to enhance numeric input <br>on iOS devices.


</details>
    

  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/158/files#diff-76a6a96298f7905c2da1e23483669b1951f5de3e0b25f37df050d78eb0878233">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>amount.svelte</strong><dd><code>Enhance Numeric Input for iOS in Market Making Amount Component</code></dd></summary>
<hr>

interface/src/lib/components/grow/marketMaking/new/easy/amount.svelte
<li>Added <code>inputmode="decimal"</code> to two input fields to ensure proper numeric <br>input on iOS.


</details>
    

  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/158/files#diff-459a25a5ea5b96b0229135f3d0cef5dfc4bb8b073efd3be20b13d92890eade55">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inputs.svelte</strong><dd><code>Enhance Numeric Input for iOS in Spot Bids Inputs Component</code></dd></summary>
<hr>

interface/src/lib/components/spot/bids/inputs.svelte
<li>Added <code>inputmode="decimal"</code> to multiple input fields to improve numeric <br>input handling on iOS.


</details>
    

  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/158/files#diff-12445a9b778b968349e9b5aa908c04ef41c20d7fa6f232d972fb3e936a93bfd0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>input.svelte</strong><dd><code>Enhance Numeric Input for iOS in Swap Input Component</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

interface/src/lib/components/swap/input.svelte
<li>Added <code>inputmode="decimal"</code> to the input field to facilitate numeric <br>input on iOS.


</details>
    

  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/158/files#diff-3ebcc855afc26c1448e6d2669f19afae0350fd0aa75f427f7be8dc6478622973">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>output.svelte</strong><dd><code>Enhance Numeric Input for iOS in Swap Output Component</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

interface/src/lib/components/swap/output.svelte
<li>Added <code>inputmode="decimal"</code> to the output field to improve numeric input <br>on iOS.


</details>
    

  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/158/files#diff-9ddd5334cd6d09b1881f372f5c1a41de1af7fa031abbbe1eb6a429f977037b35">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

