### PR TITLE
Keep Probit Connected

### DIFF
--- a/server/src/modules/exchangeInit/exchangeInit.service.ts
+++ b/server/src/modules/exchangeInit/exchangeInit.service.ts
@@ -368,10 +368,9 @@ export class ExchangeInitService {
           for (const [label, exchange] of accounts) {
             try {
               if (exchange.has['signIn']) {
-                await exchange.signIn().then((resp) => {
-                  this.logger.log(resp);
+                await exchange.signIn().then(() => {
+                  this.logger.log(`ProBit ${label} re-signed in successfully.`);
                 }); // Explicitly refresh the session
-                this.logger.log(`ProBit ${label} re-signed in successfully.`);
               } else {
                 this.logger.warn(
                   `ProBit ${label} does not support signIn. Skipping.`,

--- a/server/src/modules/exchangeInit/exchangeInit.service.ts
+++ b/server/src/modules/exchangeInit/exchangeInit.service.ts
@@ -1,8 +1,12 @@
 import * as ccxt from 'ccxt';
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Scope,
+} from '@nestjs/common';
 import { CustomLogger } from 'src/modules/logger/logger.service';
 
-@Injectable()
+@Injectable({ scope: Scope.DEFAULT })
 export class ExchangeInitService {
   private readonly logger = new CustomLogger(ExchangeInitService.name);
   private exchanges = new Map<string, Map<string, ccxt.Exchange>>();
@@ -10,7 +14,10 @@ export class ExchangeInitService {
 
   constructor() {
     this.initializeExchanges()
-      .then(() => this.logger.log('Exchanges initialized successfully.'))
+      .then(() => {
+        this.logger.log('Exchanges initialized successfully.');
+        this.startKeepAlive();
+      })
       .catch((error) =>
         this.logger.error('Error during exchanges initialization', error),
       );
@@ -305,15 +312,36 @@ export class ExchangeInitService {
                 );
                 return;
               }
+
               const exchange = new config.class({
                 apiKey: account.apiKey,
                 secret: account.secret,
               });
+
+              // Load markets
               await exchange.loadMarkets();
+
+              // Call signIn only for ProBit accounts
+              if (config.name === 'probit' && exchange.has['signIn']) {
+                try {
+                  await exchange.signIn();
+                  this.logger.log(
+                    `${config.name} ${account.label} signed in successfully.`,
+                  );
+                } catch (error) {
+                  this.logger.warn(
+                    `ProBit ${account.label} sign-in failed: ${error.message}`,
+                  );
+                }
+              }
+
+              // Save the initialized exchange
               exchangeMap.set(account.label, exchange);
               this.logger.log(
                 `${config.name} ${account.label} initialized successfully.`,
               );
+
+              // Save the default account reference
               if (account.label === 'default') {
                 this.defaultAccounts.set(config.name, exchange);
               }
@@ -324,9 +352,40 @@ export class ExchangeInitService {
             }
           }),
         );
+
         this.exchanges.set(config.name, exchangeMap);
       }),
     );
+  }
+
+  private startKeepAlive() {
+    const intervalMs = 5 * 60 * 1000; // 5 minutes
+
+    setInterval(async () => {
+      this.logger.log('Running keep-alive checks for all exchanges...');
+      for (const [exchangeName, accounts] of this.exchanges) {
+        if (exchangeName === 'probit') {
+          for (const [label, exchange] of accounts) {
+            try {
+              if (exchange.has['signIn']) {
+                await exchange.signIn().then((resp) => {
+                  this.logger.log(resp);
+                }); // Explicitly refresh the session
+                this.logger.log(`ProBit ${label} re-signed in successfully.`);
+              } else {
+                this.logger.warn(
+                  `ProBit ${label} does not support signIn. Skipping.`,
+                );
+              }
+            } catch (error) {
+              this.logger.warn(
+                `ProBit ${label} keep-alive signIn failed: ${error.message}`,
+              );
+            }
+          }
+        }
+      }
+    }, intervalMs);
   }
 
   getExchange(exchangeName: string, label: string = 'default'): ccxt.Exchange {


### PR DESCRIPTION
### **User description**
## Description

Fix Probit disconnecting issue


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Introduced a `startKeepAlive` method to periodically refresh Probit sessions, preventing disconnections.
- Enhanced the exchange initialization process to include a sign-in step specifically for Probit accounts.
- Updated the `Injectable` decorator to specify a default scope for the `ExchangeInitService`.
- Added logging to track the success or failure of Probit sign-in attempts during initialization and keep-alive checks.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exchangeInit.service.ts</strong><dd><code>Implement keep-alive mechanism for Probit exchange</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/modules/exchangeInit/exchangeInit.service.ts

<li>Added a <code>startKeepAlive</code> method to maintain Probit connection.<br> <li> Implemented periodic keep-alive checks for Probit exchanges.<br> <li> Enhanced initialization to include Probit sign-in.<br> <li> Updated <code>Injectable</code> decorator with a default scope.<br>


</details>


  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/275/files#diff-7568abcdca44efd6412caab9f5b788bcb5158285fe49e402618f72683ae16784">+62/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information