### PR TITLE
feat: save start price of the symbol for stategy

### DIFF
--- a/server/src/common/entities/strategy-instances.entity.ts
+++ b/server/src/common/entities/strategy-instances.entity.ts
@@ -25,6 +25,9 @@ export class StrategyInstance {
   @Column()
   strategyType: string;
 
+  @Column()
+  startPrice: number;
+
   @Column('json')
   parameters: Record<string, any>;
 

--- a/server/src/database/migrations/1734370164914-addStartPriceToStrategyInstance.ts
+++ b/server/src/database/migrations/1734370164914-addStartPriceToStrategyInstance.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddStartPriceToStrategyInstance1734370164914
+  implements MigrationInterface
+{
+  name = 'AddStartPriceToStrategyInstance1734370164914';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "strategy_instances"
+            ADD "startPrice" integer NOT NULL DEFAULT 0
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "strategy_instances" DROP COLUMN "startPrice"
+        `);
+  }
+}

--- a/server/src/modules/strategy/strategy.service.ts
+++ b/server/src/modules/strategy/strategy.service.ts
@@ -256,6 +256,7 @@ export class StrategyService {
         );
       } else {
         // Otherwise, create a new instance
+        const exchange = this.exchangeInitService.getExchange(exchangeAName);
         strategyInstance = this.strategyInstanceRepository.create({
           strategyKey,
           userId,
@@ -263,10 +264,14 @@ export class StrategyService {
           strategyType: 'arbitrage',
           parameters: strategyParamsDto,
           status: 'running',
+          startPrice: await exchange
+            .fetchTicker(pair)
+            .then((ticker) => ticker.last),
         });
         await this.strategyInstanceRepository.save(strategyInstance);
       }
     }
+
     const exchangeA = this.exchangeInitService.getExchange(exchangeAName);
     const exchangeB = this.exchangeInitService.getExchange(exchangeBName);
 
@@ -390,6 +395,7 @@ export class StrategyService {
         );
       } else {
         // Create a new instance if none exists
+        const exchange = this.exchangeInitService.getExchange(exchangeName);
         strategyInstance = this.strategyInstanceRepository.create({
           strategyKey,
           userId,
@@ -405,11 +411,15 @@ export class StrategyService {
             userId,
             clientId,
           },
+          startPrice: await exchange
+            .fetchTicker(symbol)
+            .then((ticker) => ticker.last),
           status: 'running',
         });
         await this.strategyInstanceRepository.save(strategyInstance);
       }
     }
+
     try {
       const exchangeAccount1 = this.exchangeInitService.getExchange(
         exchangeName,
@@ -651,6 +661,8 @@ export class StrategyService {
         );
       } else {
         // Create a new instance if none exists
+        const exchange = this.exchangeInitService.getExchange(exchangeName);
+
         strategyInstance = this.strategyInstanceRepository.create({
           strategyKey,
           userId,
@@ -658,6 +670,9 @@ export class StrategyService {
           strategyType: 'pureMarketMaking',
           parameters: strategyParamsDto,
           status: 'running',
+          startPrice: await exchange
+            .fetchTicker(strategyParamsDto.pair)
+            .then((ticker) => ticker.last),
         });
         await this.strategyInstanceRepository.save(strategyInstance);
       }


### PR DESCRIPTION
### **User description**
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

## How to test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->


___

### **PR Type**
Enhancement


___

### **Description**
- Added a new `startPrice` column to the `StrategyInstance` entity to store the initial price of a symbol or pair.
- Implemented a database migration to add the `startPrice` column to the `strategy_instances` table with a default value of 0.
- Enhanced the `StrategyService` to fetch the latest ticker price from the exchange and save it as the `startPrice` when creating new strategy instances.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>strategy-instances.entity.ts</strong><dd><code>Add `startPrice` column to `StrategyInstance` entity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/common/entities/strategy-instances.entity.ts

- Added a new `startPrice` column to the `StrategyInstance` entity.



</details>


  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/294/files#diff-1bd17c7a4be36e2be3608745714e820ede1073d9d6d844186465371a0f29c834">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>1734370164914-addStartPriceToStrategyInstance.ts</strong><dd><code>Add migration for `startPrice` column in `strategy_instances`</code></dd></summary>
<hr>

server/src/database/migrations/1734370164914-addStartPriceToStrategyInstance.ts

<li>Created a migration to add the <code>startPrice</code> column to the <br><code>strategy_instances</code> table.<br> <li> Included default value and rollback logic for the column.<br>


</details>


  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/294/files#diff-47cf8a1fb0fc4e83955efc5889d21cb5dbb387b5d7692432c58ab322ea52eff0">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>strategy.service.ts</strong><dd><code>Fetch and save `startPrice` during strategy initialization</code></dd></summary>
<hr>

server/src/modules/strategy/strategy.service.ts

<li>Integrated logic to fetch and save the <code>startPrice</code> when creating new <br>strategy instances.<br> <li> Used exchange services to fetch the latest ticker price for the <br>relevant symbol or pair.<br>


</details>


  </td>
  <td><a href="https://github.com/Hu-Fi/Mr.Market/pull/294/files#diff-413cb1b28e0d47a46768f97d10145a8e14d9e46b0a195768786127305916d944">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information